### PR TITLE
Reflect planner component

### DIFF
--- a/crates/bevy_dogoap/src/planner.rs
+++ b/crates/bevy_dogoap/src/planner.rs
@@ -23,6 +23,7 @@ type DatumComponents = Vec<Box<dyn DatumComponent>>;
 /// Our main struct for handling the planning within Bevy, keeping track of added
 /// [`Action`]s, [`DatumComponent`]s, and some options for controlling the execution
 #[derive(Component, Reflect)]
+#[reflect(Component)]
 pub struct Planner {
     /// Our current state used for planning, updated by [`update_planner_local_state`] which reads
     /// the current state from our Bevy world and updates it accordingly


### PR DESCRIPTION
First, this is a super cool package -- thank you for creating this!

## Changes
* Reflect the planner component for broader integration with plugins using component reflection

## Testing
* Builds locally in my fork with `cargo build`
* Verified this allows bevy_dogoap and a component-reflection-based plugin to run in a game with both enabled