### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/crates/dogoap/Cargo.toml
+++ b/crates/dogoap/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 edition = "2021"
 description = "dogoap"
 license = "MIT"
-homepage = "https://github.com/victorb/dogoap"
+repository = "https://github.com/victorb/dogoap"
 
 [dependencies]
 bevy_reflect = "0.16"


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/88