### PR TITLE
chore: fix most `bevy_dogoap` example lints

### DIFF
--- a/crates/bevy_dogoap/examples/bevy_basic.rs
+++ b/crates/bevy_dogoap/examples/bevy_basic.rs
@@ -111,7 +111,7 @@ fn main() {
 
     // Lets inspect the final state of our (one) Planner we have in the World
     let mut query = app.world_mut().query::<&Planner>();
-    let planner = query.get_single(&app.world()).unwrap();
+    let planner = query.single(app.world()).unwrap();
 
     // This should confirm that is_hungry and is_tired have been set to `false`
     println!("Final state in our planner:");

--- a/crates/bevy_dogoap/examples/cells.rs
+++ b/crates/bevy_dogoap/examples/cells.rs
@@ -1,7 +1,7 @@
 use bevy::{
     color::palettes::css::*,
-    prelude::*,
     prelude::Camera2d,
+    prelude::*,
     time::common_conditions::on_timer,
     window::{Window, WindowPlugin},
 };
@@ -125,7 +125,7 @@ fn spawn_cell(commands: &mut Commands, position: Vec3, speed: f32) {
 }
 
 fn startup(mut commands: Commands, windows: Query<&Window>) {
-    let window = windows.get_single().expect("Expected only one window! Wth");
+    let window = windows.single().expect("Expected only one window! Wth");
     let window_height = window.height() / 2.0;
     let window_width = window.width() / 2.0;
 
@@ -156,7 +156,7 @@ fn spawn_random_food(
     mut commands: Commands,
     q_food: Query<Entity, With<Food>>,
 ) {
-    let window = windows.get_single().expect("Expected only one window! Wth");
+    let window = windows.single().expect("Expected only one window! Wth");
     let window_height = window.height() / 2.0;
     let window_width = window.width() / 2.0;
 
@@ -200,6 +200,7 @@ fn handle_move_to(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn handle_go_to_food_action(
     mut commands: Commands,
     mut query: Query<
@@ -252,7 +253,7 @@ fn handle_go_to_food_action(
             // Consume food!
             at_food.0 = true;
             commands.entity(entity).remove::<GoToFoodAction>();
-            targeted_food.remove(&e_food);
+            targeted_food.remove(e_food);
         }
     }
 }
@@ -340,7 +341,7 @@ fn handle_eat_action(
                     if hunger.0 < 0.0 {
                         hunger.0 = 0.0;
                     }
-                    commands.entity(*e_food).despawn_recursive();
+                    commands.entity(*e_food).despawn();
                 }
                 // Don't consume as it doesn't exists
                 Err(_) => {
@@ -371,7 +372,7 @@ fn over_time_needs_change(
         hunger.0 += val;
         if hunger.0 > 100.0 {
             // hunger.0 = 100.0;
-            commands.entity(entity).despawn_recursive();
+            commands.entity(entity).despawn();
             let translation = transform.translation;
             commands.spawn((
                 DeadCell,
@@ -383,6 +384,7 @@ fn over_time_needs_change(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn print_current_local_state(
     query: Query<(Entity, &Cell, &Hunger, &Children)>,
     q_actions: Query<(
@@ -394,7 +396,7 @@ fn print_current_local_state(
     q_child: Query<Entity, With<StateDebugText>>,
     mut text_writer: Text2dWriter,
 ) {
-    // let planner = query.get_single().unwrap();
+    // let planner = query.single().unwrap();
     for (entity, cell, hunger, children) in query.iter() {
         let age = cell.age;
         let hunger = hunger.0;

--- a/crates/bevy_dogoap/examples/miner.rs
+++ b/crates/bevy_dogoap/examples/miner.rs
@@ -1,7 +1,7 @@
 use bevy::{
     color::palettes::css::*,
-    prelude::*,
     prelude::Camera2d,
+    prelude::*,
     time::common_conditions::on_timer,
     window::{Window, WindowPlugin},
 };
@@ -253,7 +253,7 @@ fn startup(mut commands: Commands, windows: Query<&Window>) {
         Transform::from_translation(Vec3::new(-300.0, -50.0, 0.0)),
     ));
 
-    let window = windows.get_single().expect("Expected only one window! Wth");
+    let window = windows.single().expect("Expected only one window! Wth");
     let window_height = window.height() / 2.0;
     let window_width = window.width() / 2.0;
 
@@ -292,7 +292,7 @@ fn spawn_random_mushroom(
     mushrooms: Query<Entity, With<Mushroom>>,
 ) {
     if mushrooms.iter().len() < 10 {
-        let window = windows.get_single().expect("Expected only one window! Wth");
+        let window = windows.single().expect("Expected only one window! Wth");
         let window_height = window.height() / 2.0;
         let window_width = window.width() / 2.0;
 
@@ -314,7 +314,7 @@ fn spawn_random_ore(
     ores: Query<Entity, With<Ore>>,
 ) {
     if ores.iter().len() < 10 {
-        let window = windows.get_single().expect("Expected only one window! Wth");
+        let window = windows.single().expect("Expected only one window! Wth");
         let window_height = window.height() / 2.0;
         let window_width = window.width() / 2.0;
 
@@ -361,9 +361,7 @@ fn handle_go_to_house_action(
     q_house: Query<&Transform, With<House>>,
 ) {
     for (entity, _action, mut t_entity, mut at_location) in query.iter_mut() {
-        let t_house = q_house
-            .get_single()
-            .expect("There should only be one house!");
+        let t_house = q_house.single().expect("There should only be one house!");
 
         go_to_location::<GoToHouseAction>(
             &mut at_location,
@@ -388,7 +386,7 @@ fn handle_go_to_smelter_action(
 ) {
     for (entity, _action, mut t_entity, mut at_location) in query.iter_mut() {
         let t_smelter = q_smelter
-            .get_single()
+            .single()
             .expect("There should only be one smelter!");
 
         go_to_location::<GoToSmelterAction>(
@@ -410,9 +408,7 @@ fn handle_go_to_outside_action(
     q_house: Query<&Transform, With<House>>,
 ) {
     for (entity, _action, mut t_entity, mut at_location) in query.iter_mut() {
-        let t_house = q_house
-            .get_single()
-            .expect("There should only be one house!");
+        let t_house = q_house.single().expect("There should only be one house!");
 
         // Outside is slightly to the left of the house... Fight me
         let offset = Vec3::new(-30.0, 0.0, 0.0);
@@ -441,7 +437,7 @@ fn handle_go_to_merchant_action(
 ) {
     for (entity, _action, mut t_entity, mut at_location) in query.iter_mut() {
         let t_destination = q_destination
-            .get_single()
+            .single()
             .expect("There should only be one merchant!");
 
         go_to_location::<GoToMerchantAction>(
@@ -532,10 +528,8 @@ fn find_closest(origin: Vec3, items: Vec<(Entity, Transform)>) -> Option<(Entity
             }
         }
     }
-    match closest {
-        Some((e, t, _f)) => Some((e, t.translation)),
-        None => None,
-    }
+
+    closest.map(|(e, t, _f)| (e, t.translation))
 }
 
 fn handle_eat_action(
@@ -557,7 +551,7 @@ fn handle_eat_action(
         let items: Vec<(Entity, Transform)> = q_mushrooms.iter().map(|(e, t)| (e, *t)).collect();
         let mushroom = find_closest(origin, items);
 
-        println!("Eating mushroom we found at {:?}", mushroom);
+        println!("Eating mushroom we found at {mushroom:?}");
 
         let mushroom = match mushroom {
             Some(v) => v,
@@ -567,7 +561,7 @@ fn handle_eat_action(
         hunger.0 -= 50.0;
 
         commands.entity(entity).remove::<EatAction>();
-        commands.entity(mushroom.0).despawn_recursive();
+        commands.entity(mushroom.0).despawn();
 
         at_location.0 = Location::Outside;
     }
@@ -629,6 +623,7 @@ fn action_with_progress<F>(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn handle_mine_ore_action(
     time: Res<Time>,
     mut commands: Commands,
@@ -667,7 +662,7 @@ fn handle_mine_ore_action(
                     at_location.0 = Location::Outside;
 
                     commands.entity(entity).remove::<MineOreAction>();
-                    commands.entity(closest.0).despawn_recursive();
+                    commands.entity(closest.0).despawn();
                 } else {
                     let mut rng = rand::thread_rng();
 
@@ -686,6 +681,7 @@ fn handle_mine_ore_action(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn handle_smelt_ore_action(
     time: Res<Time>,
     mut commands: Commands,
@@ -740,6 +736,7 @@ fn handle_smelt_ore_action(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn handle_sell_metal_action(
     time: Res<Time>,
     mut commands: Commands,
@@ -797,6 +794,7 @@ fn over_time_needs_change(time: Res<Time>, mut query: Query<(&mut Hunger, &mut E
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn print_current_local_state(
     query: Query<(
         Entity,
@@ -924,19 +922,19 @@ fn draw_gizmos(
     }
 
     gizmos.rect_2d(
-        q_house.get_single().unwrap().translation.truncate(),
+        q_house.single().unwrap().translation.truncate(),
         Vec2::new(40.0, 80.0),
         AQUAMARINE,
     );
 
     gizmos.rect_2d(
-        q_smelter.get_single().unwrap().translation.truncate(),
+        q_smelter.single().unwrap().translation.truncate(),
         Vec2::new(30.0, 30.0),
         YELLOW_GREEN,
     );
 
     gizmos.circle_2d(
-        q_merchant.get_single().unwrap().translation.truncate(),
+        q_merchant.single().unwrap().translation.truncate(),
         16.,
         GOLD,
     );

--- a/crates/bevy_dogoap/examples/resman.rs
+++ b/crates/bevy_dogoap/examples/resman.rs
@@ -35,8 +35,8 @@ use std::collections::{HashMap, VecDeque};
 
 use bevy::{
     color::palettes::css::*,
-    prelude::*,
     prelude::Camera2d,
+    prelude::*,
     window::{Window, WindowPlugin},
 };
 use bevy_dogoap::prelude::*;
@@ -410,6 +410,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2d);
 }
 
+#[allow(clippy::type_complexity)]
 fn handle_call_worker_to_empty_order_desk(
     mut commands: Commands,
     mut q_order_desks: Query<(&mut OrderDesk, &Transform)>,
@@ -448,6 +449,7 @@ fn handle_move_to(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn handle_go_to_order_desk(
     mut commands: Commands,
     mut q_order_desks: Query<(&Transform, &mut OrderDesk)>,
@@ -537,7 +539,7 @@ fn handle_place_order(
 ) {
     for (entity, mut customer, _action, mut placed_order) in query.iter_mut() {
         let mut order_desk = q_order_desks
-            .get_single_mut()
+            .single_mut()
             .expect("Only one order desk expected!");
         // Need to make sure the serving counter has a worker at it before we
         // can place an order
@@ -666,9 +668,8 @@ fn draw_state_debug(
 
         // Get current action, should always be one so grab the first one we find
         for (_entity, actions) in q_actions.get(entity).iter() {
-            for action in actions.iter() {
+            if let Some(action) = actions.iter().next() {
                 current_action = action.action_type_name();
-                break;
             }
         }
 
@@ -679,12 +680,12 @@ fn draw_state_debug(
                 state = format!(
                     "{}\n{}: {}",
                     state,
-                    datum.field_key().to_string(),
+                    datum.field_key(),
                     match datum.field_value() {
                         Datum::Bool(v) => v.to_string(),
-                        Datum::F64(v) => format!("{:.2}", v).to_string(),
-                        Datum::I64(v) => format!("{}", v).to_string(),
-                        Datum::Enum(v) => format!("{}", v).to_string(),
+                        Datum::F64(v) => format!("{v:.2}"),
+                        Datum::I64(v) => format!("{v}"),
+                        Datum::Enum(v) => format!("{v}"),
                     }
                 );
             }


### PR DESCRIPTION
Updated deprecated methods in `bevy_dogoap` and other lints that clippy was angry about.

Did not fix any lints that matched `unused_variables` or `dead_code`. Let me know if you would like me to include these.

Additionally, I manually marked off functions with `#[allow(clippy::type_complexity)]`, but let me know if you'd prefer this to be a crate-wide allow lint, which is standard for bevy crates :)